### PR TITLE
Add support for 3rd party binder servers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           target-repo: s-weigand/flake8-nb
           use-default-build-servers: false
-          additional-build-server: |
+          additional-build-servers: |
             foo
           debug: true
       - name: Test fail

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: "Integration-Tests"
+name: 'Integration-Tests'
 on:
   pull_request:
 
@@ -19,6 +19,15 @@ jobs:
         uses: ./
         with:
           target-repo: s-weigand/ipynb-share
+          debug: true
+      - name: Test custom build server
+        continue-on-error: true
+        uses: ./
+        with:
+          target-repo: s-weigand/ipynb-share
+          use-default-build-servers: false
+          additional-build-server: |
+            foo
           debug: true
       - name: Test fail
         continue-on-error: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Test success
         uses: ./
         with:
-          target-repo: s-weigand/ipynb-share
+          target-repo: s-weigand/flake8-nb
           debug: true
       - name: Test custom build server
         continue-on-error: true
         uses: ./
         with:
-          target-repo: s-weigand/ipynb-share
+          target-repo: s-weigand/flake8-nb
           use-default-build-servers: false
           additional-build-server: |
             foo
@@ -33,6 +33,6 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          target-repo: s-weigand/ipynb-share
+          target-repo: s-weigand/flake8-nb
           target-state: not-a-branch
           debug: true

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ input and not read from the environment, since this prevents unnecessary builds 
 
 ## Inputs
 
-| Name           | Requirement | Default    | Description                                                                            |
-| -------------- | ----------- | ---------- | -------------------------------------------------------------------------------------- |
-| `target-repo`  | _required_  |            | Repository which should be build by mybinder.org .                                     |
-| `service-name` | _optional_  | `'gh'`     | gh \| gist \| gl \| git \| zenodo \| figshare Name of the service that hosts the repo. |
-| `target-state` | _optional_  | `'master'` | Name of the branch, tag or commit which should be build, by mybinder.org.              |
-| `debug`        | _optional_  | `false`    | If this is true all server response messages will be printed to console.               |
+| Name                        | Requirement | Default    | Description                                                                                                                                    |
+| --------------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target-repo`               | _required_  |            | Repository which should be build by mybinder.org .                                                                                             |
+| `service-name`              | _required_  | `'gh'`     | gh \| gist \| gl \| git \| zenodo \| figshare Name of the service that hosts the repo.                                                         |
+| `target-state`              | _optional_  | `'master'` | Name of the branch, tag or commit which should be build, by mybinder.org.                                                                      |
+| `use-default-build-servers` | _optional_  | `true`     | Whether or not to use the default mybinder.org build servers. If false and additional-build-server is not specified, this will throw an error. |
+| `additional-build-servers`  | _optional_  | `''`       | Newline separated list of urls, which point do binder build servers base url.                                                                  |
+| `debug`                     | _optional_  | `false`    | If this is true all server response messages will be printed to console.                                                                       |
 
 ## Usage
 
@@ -45,6 +47,8 @@ jobs:
           target-repo: <my-github-handle>/<my-repo-name>
 ```
 
+### Customized:
+
 ```yaml
 name: 'Trigger-Binder-build'
 on:
@@ -61,5 +65,9 @@ jobs:
           target-repo: <my-gitlab-handle>/<my-repo-name>
           service-name: gl
           target-state: <binder-branch-tag-commit>
+          use-default-build-servers: false
+          additional-build-servers: |
+            <build-server-url-1>
+            <build-server-url-2>
           debug: true
 ```

--- a/__tests__/load-config.test.ts
+++ b/__tests__/load-config.test.ts
@@ -1,10 +1,25 @@
-import { loadConfig } from '../src/load-config'
+import {
+  loadConfig,
+  validateConfig,
+  TriggerBinderConfig,
+} from '../src/load-config'
 
 const testEnvVars = {
   'INPUT_TARGET-REPO': 'user_name/repo_name',
   'INPUT_SERVICE-NAME': 'gist',
   'INPUT_TARGET-STATE': 'bar',
+  'INPUT_USE-DEFAULT-BUILD-SERVERS': 'true',
+  'INPUT_ADDITIONAL-BUILD-SERVERS': '',
   INPUT_DEBUG: 'true',
+}
+
+const defaultConfig = {
+  targetRepo: 'user_name/repo_name',
+  serviceName: 'gist',
+  targetState: 'bar',
+  useDefaultBuildServers: true,
+  additionalBuildServers: [],
+  debug: true,
 }
 
 describe('Reading of the config', () => {
@@ -22,9 +37,44 @@ describe('Reading of the config', () => {
 
   it('test config values', () => {
     const config = loadConfig()
-    expect(config.targetRepo).toEqual('user_name/repo_name')
-    expect(config.serviceName).toEqual('gist')
-    expect(config.targetState).toEqual('bar')
-    expect(config.debug).toEqual(true)
+    expect(config.targetRepo).toEqual(defaultConfig.targetRepo)
+    expect(config.serviceName).toEqual(defaultConfig.serviceName)
+    expect(config.targetState).toEqual(defaultConfig.targetState)
+    expect(config.useDefaultBuildServers).toBe(
+      defaultConfig.useDefaultBuildServers,
+    )
+    expect(config.additionalBuildServers).toMatchObject(
+      defaultConfig.additionalBuildServers,
+    )
+    expect(config.debug).toEqual(defaultConfig.debug)
+  })
+  it('test additional-build-servers none empty values', () => {
+    process.env['INPUT_ADDITIONAL-BUILD-SERVERS'] = 'foo\nbar'
+    const config = loadConfig()
+    expect(config.additionalBuildServers).toMatchObject(['foo', 'bar'])
+  })
+})
+
+describe('Validation of the config', () => {
+  it('test serviceName error', () => {
+    const wrongServiceNameConfig = { ...defaultConfig }
+    wrongServiceNameConfig.serviceName = 'foo-bar'
+    expect(() => {
+      validateConfig(wrongServiceNameConfig as any)
+    }).toThrow('service-name')
+  })
+  it('test servicesWithNoFixedState error', () => {
+    const wrongServiceWithNoFixedState = { ...defaultConfig }
+    wrongServiceWithNoFixedState.serviceName = 'zenodo'
+    expect(() => {
+      validateConfig(wrongServiceWithNoFixedState as any)
+    }).toThrow('target-state')
+  })
+  it('test wrongBuildServerCongig', () => {
+    const wrongBuildServerCongig = { ...defaultConfig }
+    wrongBuildServerCongig.useDefaultBuildServers = false
+    expect(() => {
+      validateConfig(wrongBuildServerCongig as any)
+    }).toThrow('use-default-build-servers')
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: "Trigger binder build"
-description: "Triggers the build of a repository on mybinder.org"
-author: "Sebastian Weigand"
+name: 'Trigger binder build'
+description: 'Triggers the build of a repository on mybinder.org'
+author: 'Sebastian Weigand'
 inputs:
   target-repo:
-    description: "Repository which should be build"
+    description: 'Repository which should be build'
     required: true
   service-name:
     description: "gh|gist|gl|git|zenodo|figshare Name of the service that hosts the repo. Default: 'gh'"
@@ -12,16 +12,24 @@ inputs:
   target-state:
     description: "Name of the branch, tag or commit which should be build. Default: 'master'"
     required: false
-    default: "master"
+    default: 'master'
+  use-default-build-servers:
+    description: 'Whether or not to use the default mybinder.org build servers. If false and additional-build-server is not specified, this will throw an error. Default: true'
+    required: false
+    default: true
+  additional-build-servers:
+    description: "Newline separated list of urls, which point do binder build servers base url. Default: ''"
+    required: false
+    default: ''
   debug:
-    description: "Weather to print debug information or not. Default: 'false'"
+    description: 'Weather to print debug information or not. Default: false'
     required: false
     default: false
 
 runs:
-  using: "node12"
-  main: "dist/index.js"
+  using: 'node12'
+  main: 'dist/index.js'
 
 branding:
-  icon: "code"
-  color: "yellow"
+  icon: 'code'
+  color: 'yellow'

--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -7,6 +7,8 @@ export interface TriggerBinderConfig {
   targetRepo: string
   serviceName: ServiceName
   targetState: string
+  useDefaultBuildServers: boolean
+  additionalBuildServers: string[]
   debug: boolean
 }
 
@@ -16,12 +18,23 @@ export const loadConfig = (): TriggerBinderConfig => {
     required: true,
   }) as ServiceName
   const targetState = core.getInput('target-state')
+  const useDefaultBuildServers =
+    core.getInput('use-default-build-servers') === 'true'
+  const additionalBuildServers = core
+    .getInput('additional-build-servers')
+    .split('\n')
+    .map(additionalBuildServer => additionalBuildServer.trim())
+    .filter(additionalBuildServer => additionalBuildServer !== '')
+
   const debug = core.getInput('debug') === 'true'
-  // const targetRepo = 's-weigand/python-tools-for-students'
-  // const serviceName = 'gh' as ServiceName
-  // const targetState = 'master'
-  // const debug = true
-  const config = { targetRepo, serviceName, targetState, debug }
+  const config = {
+    targetRepo,
+    serviceName,
+    targetState,
+    useDefaultBuildServers,
+    additionalBuildServers,
+    debug,
+  }
   validateConfig(config)
   return config
 }
@@ -37,6 +50,12 @@ export const validateConfig = (config: TriggerBinderConfig): void => {
     throw new Error(`The service ${serviceName} providing the repo
     is not compatible with the option 'target-state'.
     Have a look at https://mybinder.org/.`)
+  }
+  const useDefaultBuildServers = config.useDefaultBuildServers
+  const additionalBuildServers = config.additionalBuildServers
+  if (useDefaultBuildServers === false && additionalBuildServers.length === 0) {
+    throw new Error(`If the setting 'use-default-build-servers' is 'false', 'additional-build-server'
+    needs to be set to a not empty value.`)
   }
 }
 

--- a/src/request_trigger.ts
+++ b/src/request_trigger.ts
@@ -66,18 +66,18 @@ const checkDone = (
 
 export const triggerBuilds = (config: TriggerBinderConfig): void => {
   const baseUrls: string[] = [
-    'https://mybinder.org/build',
-    'https://gke.mybinder.org/build',
-    'https://ovh.mybinder.org/build',
-    'https://gesis.mybinder.org/build',
-    'https://turing.mybinder.org/build',
+    'https://mybinder.org',
+    'https://gke.mybinder.org',
+    'https://ovh.mybinder.org',
+    'https://gesis.mybinder.org',
+    'https://turing.mybinder.org',
   ]
   const targetRepo: string = config.targetRepo
   const targetState: string = config.targetState
   const serviceName: string = config.serviceName
   const responses: Promise<boolean>[] = []
   for (let baseUrl of baseUrls) {
-    let url: string = `${baseUrl}/${serviceName}/${targetRepo}`
+    let url: string = `${baseUrl}/build/${serviceName}/${targetRepo}`
     if (targetState !== '') {
       url += '/' + targetState
     }

--- a/src/request_trigger.ts
+++ b/src/request_trigger.ts
@@ -65,7 +65,7 @@ const checkDone = (
 }
 
 export const triggerBuilds = (config: TriggerBinderConfig): void => {
-  const baseUrls: string[] = [
+  const defaultBaseUrls: string[] = [
     'https://mybinder.org',
     'https://gke.mybinder.org',
     'https://ovh.mybinder.org',
@@ -75,6 +75,11 @@ export const triggerBuilds = (config: TriggerBinderConfig): void => {
   const targetRepo: string = config.targetRepo
   const targetState: string = config.targetState
   const serviceName: string = config.serviceName
+  const useDefaultBuildServers: boolean = config.useDefaultBuildServers
+  const additionalBuildServers: string[] = config.additionalBuildServers
+  const baseUrls: string[] = useDefaultBuildServers
+    ? [...defaultBaseUrls, ...additionalBuildServers]
+    : [...additionalBuildServers]
   const responses: Promise<boolean>[] = []
   for (let baseUrl of baseUrls) {
     let url: string = `${baseUrl}/build/${serviceName}/${targetRepo}`


### PR DESCRIPTION
This PR adds the capability to add additional build servers and to deactivate the default build servers.

closes #6 