### PR TITLE
Fix timeout

### DIFF
--- a/__tests__/request_trigger.test.ts
+++ b/__tests__/request_trigger.test.ts
@@ -4,7 +4,7 @@ describe('Testing requests', () => {
   it('test dummy request', () => {
     return expect(
       requestBuild(
-        'https://gke.mybinder.org/build/gh/s-weigand/ipynb-share/master',
+        'https://gke.mybinder.org/build/gh/s-weigand/flake8-nb/master',
         false,
       ),
     ).resolves.toBe('success')
@@ -12,7 +12,7 @@ describe('Testing requests', () => {
   it('test error request', () => {
     return expect(
       requestBuild(
-        'https://gke.mybinder.org/build/gh/s-weigand/ipynb-share/not-a-branch',
+        'https://gke.mybinder.org/build/gh/s-weigand/flake8-nb/not-a-branch',
         false,
       ),
     ).rejects.toMatch('Build Error')

--- a/src/request_trigger.ts
+++ b/src/request_trigger.ts
@@ -1,9 +1,8 @@
 import * as core from '@actions/core'
 
-import EventSource, { EventSourceInitDict } from 'eventsource'
+import EventSource from 'eventsource'
 
 import { TriggerBinderConfig } from './load-config'
-import { resolve } from 'dns'
 
 interface BuildServerResponse {
   phase: string
@@ -13,6 +12,7 @@ interface BuildServerResponse {
 
 export const requestBuild = (url: string, debug: boolean): Promise<string> => {
   const timeOut = 30000
+  const maxTimeOut = timeOut + 10000
   const startTime = new Date().getTime()
   const source = new EventSource(url)
   return new Promise((resolve, reject) => {
@@ -47,8 +47,11 @@ export const requestBuild = (url: string, debug: boolean): Promise<string> => {
     // fail save in case there are no messages and no errors
     setTimeout(() => {
       source.close()
-      reject('Request Error ${url}\nConnection timed out.')
-    }, timeOut + 10000)
+      reject(
+        `Request Error ${url}\nConnection timed out, via fail save after ${maxTimeOut /
+          1000}s.`,
+      )
+    }, maxTimeOut)
   })
 }
 

--- a/src/request_trigger.ts
+++ b/src/request_trigger.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 
-import EventSource from 'eventsource'
+import EventSource, { EventSourceInitDict } from 'eventsource'
 
 import { TriggerBinderConfig } from './load-config'
 import { resolve } from 'dns'
@@ -44,6 +44,11 @@ export const requestBuild = (url: string, debug: boolean): Promise<string> => {
       reject(`Request Error ${url}\nAn Error occurred requesting a binder build:\n
     ${event.data}`)
     }
+    // fail save in case there are no messages and no errors
+    setTimeout(() => {
+      source.close()
+      reject('Request Error ${url}\nConnection timed out.')
+    }, timeOut + 10000)
   })
 }
 


### PR DESCRIPTION
In case the server doesn't respond at all (`onmessage` and `onerror` never get triggered), the action will run 'forerver' (current timeout limit is 6h) and will fail.
This PR adds a fail save via `setTimeout`, which rejects the `Promiss` after `timeOut+10000` (40s).