### PR TITLE
Fix broken test due to outdated target branch name

### DIFF
--- a/__tests__/request_trigger.test.ts
+++ b/__tests__/request_trigger.test.ts
@@ -4,7 +4,7 @@ describe('Testing requests', () => {
   it('test dummy request', () => {
     return expect(
       requestBuild(
-        'https://ovh.mybinder.org/build/gh/s-weigand/flake8-nb/master',
+        'https://ovh.mybinder.org/build/gh/s-weigand/flake8-nb/main',
         false,
       ),
     ).resolves.toBe('success')


### PR DESCRIPTION
Changed flake8-nb branch to be tested to main since master was renamed.